### PR TITLE
Change Double Quotes Behavior

### DIFF
--- a/sqlparser/ast.go
+++ b/sqlparser/ast.go
@@ -2622,14 +2622,14 @@ func formatID(buf *TrackedBuffer, original, lowered string) {
 	return
 
 mustEscape:
-	buf.WriteByte('`')
+	buf.WriteByte('"')
 	for _, c := range original {
 		buf.WriteRune(c)
-		if c == '`' {
-			buf.WriteByte('`')
+		if c == '"' {
+			buf.WriteByte('"')
 		}
 	}
-	buf.WriteByte('`')
+	buf.WriteByte('"')
 }
 
 func compliantName(in string) string {

--- a/sqlparser/token_test.go
+++ b/sqlparser/token_test.go
@@ -16,7 +16,21 @@ limitations under the License.
 
 package sqlparser
 
-import "testing"
+import (
+	"testing"
+)
+
+func TestDoubleQuotes(t *testing.T) {
+	inputSQL := "select * from temp where \"global id\" = 'ab`cd'"
+	stmt, err := Parse(inputSQL)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	outputSQL := String(stmt)
+	if inputSQL != outputSQL {
+		t.Errorf("Input and output SQLs are not equal")
+	}
+}
 
 func TestLiteralID(t *testing.T) {
 	testcases := []struct {
@@ -24,31 +38,31 @@ func TestLiteralID(t *testing.T) {
 		id  int
 		out string
 	}{{
-		in:  "`aa`",
+		in:  "\"aa\"",
 		id:  ID,
 		out: "aa",
 	}, {
-		in:  "```a```",
+		in:  "\"\"\"a\"\"\"",
 		id:  ID,
-		out: "`a`",
+		out: "\"a\"",
 	}, {
-		in:  "`a``b`",
+		in:  "\"a\"\"b\"",
 		id:  ID,
-		out: "a`b",
+		out: "a\"b",
 	}, {
-		in:  "`a``b`c",
+		in:  "\"a\"\"b\"c",
 		id:  ID,
-		out: "a`b",
+		out: "a\"b",
 	}, {
-		in:  "`a``b",
+		in:  "\"a\"\"b",
 		id:  LEX_ERROR,
-		out: "a`b",
+		out: "a\"b",
 	}, {
-		in:  "`a``b``",
+		in:  "\"a\"\"b\"\"",
 		id:  LEX_ERROR,
-		out: "a`b`",
+		out: "a\"b\"",
 	}, {
-		in:  "``",
+		in:  "\"\"",
 		id:  LEX_ERROR,
 		out: "",
 	}}


### PR DESCRIPTION
In order to use the SQL Parser for Athena SQL, we need to change the behavior of tokens that are enclosed in double quotes. Instead of treating them as strings like in MySQL, treat them as identifiers (column and table names) like in Athena.
In addition, the SQL Parser is not allowed to include tokens that are enclosed in backticks now. I did it for reasons of code simplicity and the fact that backtricks are used to escape reserved keywords in DDL statements and our parser isn't supposed to parse DDL statements.